### PR TITLE
Multi enable

### DIFF
--- a/doc/pulse.txt
+++ b/doc/pulse.txt
@@ -256,9 +256,10 @@ pulse.enable({timer})                                           *pulse.enable()*
         end
 <
 
-:PulseEnable {timer}                                              *:PulseEnable*
-    Enables the timer with the matching name, otherwise reports failure. >vim
+:PulseEnable {timers}                                             *:PulseEnable*
+    Enables the timers with the matching name, otherwise reports failure. >vim
     :PulseEnable break-timer
+    :PulseEnable timer-one timer-two
 <
 pulse.disable({timer})                                         *pulse.disable()*
     Disables the timer with the matching name.
@@ -277,9 +278,10 @@ pulse.disable({timer})                                         *pulse.disable()*
             vim.print("Something went wrong!")
         end
 <
-:PulseDisable {timer}                                            *:PulseDisable*
-    Disables the timer with the matching name, otherwise reports failure. >vim
+:PulseDisable {timers}                                           *:PulseDisable*
+    Disables the timers with the matching name, otherwise reports failure. >vim
     :PulseDisable break-timer
+    :PulseDisable timer-one timer-two
 <
 pulse.status({timer})                                           *pulse.status()*
     Returns the amount of time remaining before the specified timer goes off,

--- a/lua/pulse/init.lua
+++ b/lua/pulse/init.lua
@@ -47,7 +47,17 @@ M.setup = function(opts)
             vim.print("Timer '" .. timer .. "' is already enabled.")
             ::continue::
         end
-    end, { nargs = "+", desc = "Enables the timers with the matching name." })
+    end, {
+        nargs = "+",
+        desc = "Enables the timers with the matching name.",
+        complete = function(_, _, _)
+            local timer_names = {}
+            for k, v in pairs(M._timers) do
+                if not v.enabled() then table.insert(timer_names, k) end
+            end
+            return timer_names
+        end,
+    })
 
     vim.api.nvim_create_user_command("PulseDisable", function(args)
         for _, timer in ipairs(args.fargs) do
@@ -65,7 +75,17 @@ M.setup = function(opts)
             vim.print("Timer '" .. timer .. "' is already disabled.")
             ::continue::
         end
-    end, { nargs = "+", desc = "Disables the timers with the matching name." })
+    end, {
+        nargs = "+",
+        desc = "Disables the timers with the matching name.",
+        complete = function(_, _, _)
+            local timer_names = {}
+            for k, v in pairs(M._timers) do
+                if v.enabled() then table.insert(timer_names, k) end
+            end
+            return timer_names
+        end,
+    })
 
     vim.api.nvim_create_user_command("PulseStatus", function(args)
         local r_hours, r_minutes = M.status(args.args)
@@ -74,7 +94,17 @@ M.setup = function(opts)
             return
         end
         vim.print(timer_format(r_hours, r_minutes) .. " remaining on '" .. args.args .. "' timer.")
-    end, { nargs = 1, desc = "Prints the remaining time left on the specified timer." })
+    end, {
+        nargs = 1,
+        desc = "Prints the remaining time left on the specified timer.",
+        complete = function(_, _, _)
+            local timer_names = {}
+            for k, _ in pairs(M._timers) do
+                table.insert(timer_names, k)
+            end
+            return timer_names
+        end,
+    })
 
     vim.api.nvim_create_user_command("PulseSetTimer", function(args)
         local arguments = vim.split(args.args, " ")

--- a/lua/pulse/init.lua
+++ b/lua/pulse/init.lua
@@ -33,34 +33,39 @@ M.setup = function(opts)
 
     -- User commands for interacting with the pulse module
     vim.api.nvim_create_user_command("PulseEnable", function(args)
-        local success = M.enable(args.args)
+        for _, timer in ipairs(args.fargs) do
+            local success = M.enable(timer)
+            if success then
+                vim.print("Timer '" .. timer .. "' enabled.")
+                goto continue
+            end
 
-        if success then
-            vim.print("Timer '" .. args.args .. "' enabled.")
-            return
+            if not success and not M._timers[timer] then
+                vim.print("Timer '" .. timer .. "' does not exist.")
+                goto continue
+            end
+            vim.print("Timer '" .. timer .. "' is already enabled.")
+            ::continue::
         end
-
-        if not success and not M._timers[args.args] then
-            vim.print("Timer '" .. args.args .. "' does not exist.")
-            return
-        end
-        vim.print("Timer '" .. args.args .. "' is already enabled.")
-    end, { nargs = 1, desc = "Enables the timer with the matching name." })
+    end, { nargs = "+", desc = "Enables the timers with the matching name." })
 
     vim.api.nvim_create_user_command("PulseDisable", function(args)
-        local success = M.disable(args.args)
+        for _, timer in ipairs(args.fargs) do
+            local success = M.disable(timer)
 
-        if success then
-            vim.print("Timer '" .. args.args .. "' disabled.")
-            return
-        end
+            if success then
+                vim.print("Timer '" .. timer .. "' disabled.")
+                goto continue
+            end
 
-        if not success and not M._timers[args.args] then
-            vim.print("Timer '" .. args.args .. "' does not exist.")
-            return
+            if not success and not M._timers[timer] then
+                vim.print("Timer '" .. timer .. "' does not exist.")
+                goto continue
+            end
+            vim.print("Timer '" .. timer .. "' is already disabled.")
+            ::continue::
         end
-        vim.print("Timer '" .. args.args .. "' is already disabled.")
-    end, { nargs = 1, desc = "Disables the timer with the matching name." })
+    end, { nargs = "+", desc = "Disables the timers with the matching name." })
 
     vim.api.nvim_create_user_command("PulseStatus", function(args)
         local r_hours, r_minutes = M.status(args.args)

--- a/tests/command_spec.lua
+++ b/tests/command_spec.lua
@@ -49,6 +49,91 @@ describe("PulseEnable", function()
         require("pulse").setup()
         vim.cmd("PulseEnable dne-timer")
     end)
+
+    it("enables multiple timers", function()
+        local pulse = require("pulse")
+        pulse.setup()
+
+        local timer_names = { "disabled-timer", "disabled-timer-2", "disabled-timer-3" }
+        for _, timer_name in ipairs(timer_names) do
+            assert.is_true(pulse.add(timer_name, {
+                interval = 10,
+                enabled = false,
+            }))
+        end
+
+        for _, timer_name in ipairs(timer_names) do
+            assert.is_false(pulse._timers[timer_name].enabled())
+        end
+        vim.cmd("PulseEnable " .. table.concat(timer_names, " "))
+        for _, timer_name in ipairs(timer_names) do
+            assert.is_true(pulse._timers[timer_name].enabled())
+        end
+    end)
+
+    it("enables some timers even if one is already enabled", function()
+        local pulse = require("pulse")
+        pulse.setup()
+
+        local timer_settings = {
+            { name = "disabled-timer", enabled = false },
+            { name = "enabled-timer", enabled = true },
+            { name = "disabled-timer-2", enabled = false },
+        }
+        for _, timer in ipairs(timer_settings) do
+            assert.is_true(pulse.add(timer.name, {
+                interval = 10,
+                enabled = timer.enabled,
+            }))
+        end
+
+        for _, timer in ipairs(timer_settings) do
+            assert.equal(timer.enabled, pulse._timers[timer.name].enabled())
+        end
+
+        vim.cmd("PulseEnable " .. table.concat(vim.tbl_map(function(timer) return timer.name end, timer_settings), " "))
+
+        for _, timer in ipairs(timer_settings) do
+            assert.is_true(pulse._timers[timer.name].enabled())
+        end
+    end)
+
+    it("enables some timers even if one does not exist", function()
+        local pulse = require("pulse")
+        pulse.setup()
+
+        local timer_settings = {
+            { name = "disabled-timer", enabled = false, dne = false },
+            { name = "disabled-timer-2", enabled = false, dne = false },
+            { name = "dne-timer", enabled = false, dne = true },
+        }
+        for _, timer in ipairs(timer_settings) do
+            if not timer.dne then -- Only add timers that should exist
+                assert.is_true(pulse.add(timer.name, {
+                    interval = 10,
+                    enabled = timer.enabled,
+                }))
+            end
+        end
+
+        for _, timer in ipairs(timer_settings) do
+            if not timer.dne then
+                assert.equal(timer.enabled, pulse._timers[timer.name].enabled())
+            else
+                assert.equal(nil, pulse._timers[timer.name])
+            end
+        end
+
+        vim.cmd("PulseEnable " .. table.concat(vim.tbl_map(function(timer) return timer.name end, timer_settings), " "))
+
+        for _, timer in ipairs(timer_settings) do
+            if not timer.dne then
+                assert.is_true(pulse._timers[timer.name].enabled())
+            else
+                assert.equal(nil, pulse._timers[timer.name])
+            end
+        end
+    end)
 end)
 
 describe("PulseDisable", function()
@@ -90,6 +175,93 @@ describe("PulseDisable", function()
     it("gracefully fails when the timer does not exist", function()
         require("pulse").setup()
         vim.cmd("PulseDisable dne-timer")
+    end)
+
+    it("disables multiple timers", function()
+        local pulse = require("pulse")
+        pulse.setup()
+
+        local timer_names = { "enabled-timer", "enabled-timer-2", "enabled-timer-3" }
+        for _, timer_name in ipairs(timer_names) do
+            assert.is_true(pulse.add(timer_name, {
+                interval = 10,
+                enabled = true,
+            }))
+        end
+
+        for _, timer_name in ipairs(timer_names) do
+            assert.is_true(pulse._timers[timer_name].enabled())
+        end
+        vim.cmd("PulseDisable " .. table.concat(timer_names, " "))
+        for _, timer_name in ipairs(timer_names) do
+            assert.is_false(pulse._timers[timer_name].enabled())
+        end
+    end)
+
+    it("disables some timers even if one is already disabled", function()
+        local pulse = require("pulse")
+        pulse.setup()
+
+        local timer_settings = {
+            { name = "enabled-timer", enabled = true },
+            { name = "disabled-timer", enabled = false },
+            { name = "enabled-timer-2", enabled = true },
+        }
+        for _, timer in ipairs(timer_settings) do
+            assert.is_true(pulse.add(timer.name, {
+                interval = 10,
+                enabled = timer.enabled,
+            }))
+        end
+
+        for _, timer in ipairs(timer_settings) do
+            assert.equal(timer.enabled, pulse._timers[timer.name].enabled())
+        end
+
+        vim.cmd(
+            "PulseDisable " .. table.concat(vim.tbl_map(function(timer) return timer.name end, timer_settings), " ")
+        )
+
+        for _, timer in ipairs(timer_settings) do
+            assert.is_false(pulse._timers[timer.name].enabled())
+        end
+    end)
+
+    it("disables some timers even if one does not exist", function()
+        local pulse = require("pulse")
+        pulse.setup()
+
+        local timer_settings = {
+            { name = "enabled-timer", enabled = true, dne = false },
+            { name = "enabled-timer-2", enabled = true, dne = false },
+            { name = "dne-timer", enabled = false, dne = true },
+        }
+        for _, timer in ipairs(timer_settings) do
+            if not timer.dne then -- Only add timers that should exist
+                assert.is_true(pulse.add(timer.name, {
+                    interval = 10,
+                    enabled = timer.enabled,
+                }))
+            end
+        end
+
+        for _, timer in ipairs(timer_settings) do
+            if not timer.dne then
+                assert.equal(timer.enabled, pulse._timers[timer.name].enabled())
+            else
+                assert.equal(nil, pulse._timers[timer.name])
+            end
+        end
+
+        vim.cmd("PulseDisable " .. table.concat(vim.tbl_map(function(timer) return timer.name end, timer_settings), " "))
+
+        for _, timer in ipairs(timer_settings) do
+            if not timer.dne then
+                assert.is_false(pulse._timers[timer.name].enabled())
+            else
+                assert.equal(nil, pulse._timers[timer.name])
+            end
+        end
     end)
 end)
 

--- a/tests/command_spec.lua
+++ b/tests/command_spec.lua
@@ -253,7 +253,9 @@ describe("PulseDisable", function()
             end
         end
 
-        vim.cmd("PulseDisable " .. table.concat(vim.tbl_map(function(timer) return timer.name end, timer_settings), " "))
+        vim.cmd(
+            "PulseDisable " .. table.concat(vim.tbl_map(function(timer) return timer.name end, timer_settings), " ")
+        )
 
         for _, timer in ipairs(timer_settings) do
             if not timer.dne then


### PR DESCRIPTION
# Multi-select timers in commands

This PR adds the capacity to multi-select timers when using the `:PulseEnable` and `:PulseStatus` commands. This way, users can disable and enable multiple timers at once.

# Auto complete

The following commands now have auto complete suggestions for arguments (timer names):
- `:PulseEnable`
- `:PulseDisable`
- `:PulseStatus`