### PR TITLE
Updated readme to show that setup is required for plugin to work correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@ for managing your timers.
 Using [packer.nvim](https://github.com/wbthomason/packer.nvim)
 
 ```lua
-use { "linguini1/pulse.nvim" }
+use {
+    "linguini1/pulse.nvim",
+    config = function() require("pulse").setup() end -- Call setup to get the basic config
+}
 ```
 
 Using [lazy.nvim](https://github.com/folke/lazy.nvim)
@@ -26,8 +29,11 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 {
     "linguini1/pulse.nvim",
     version = "*", -- Latest stable release
+    config = function() require("pulse").setup() end -- Call setup to get the basic config
 }
 ```
+
+You must call `pulse.setup()` in order to get access to the editor commands and default functionality.
 
 ### Configuration
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 }
 ```
 
-You must call `pulse.setup()` in order to get access to the editor commands and default functionality.
+You must call `setup()` in order to get access to the editor commands and default functionality.
 
 ### Configuration
 
@@ -51,7 +51,8 @@ pulse.setup({
 Once you have `setup` pulse.nvim, you can add timers using the below format. See `:h pulse.add()` for more information.
 
 ```lua
---- Parameters: name, interval, message, enabled
+local pulse = require("pulse")
+pulse.setup()
 pulse.add("break-timer", {
     interval = 60,
     message = "Take a break!",


### PR DESCRIPTION
I should have included that the `setup()` call to `pulse.nvim` was required to get access to editor commands. This documentation patch clarifies that and shows the base install configuration.

This closes #4.